### PR TITLE
Use latest version of Gradle.

### DIFF
--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'com.google.gms:google-services:1.3.0'
     }
 }


### PR DESCRIPTION
Finally, we can support non-beta gradle that has support for instant run.