### PR TITLE
Fixed NullPointerException when there is no HeroView on Android.

### DIFF
--- a/Android/notifications/src/main/java/com/facebook/notifications/internal/view/BodyView.java
+++ b/Android/notifications/src/main/java/com/facebook/notifications/internal/view/BodyView.java
@@ -58,6 +58,9 @@ public class BodyView extends RelativeLayout {
     int corners = actionsStyle == ActionsConfiguration.ActionsStyle.Detached
       ? RoundedViewHelper.BOTTOM_LEFT | RoundedViewHelper.BOTTOM_RIGHT
       : 0;
+    if (config.getHeroConfiguration() == null && configuration != null) {
+      corners |= RoundedViewHelper.TOP_LEFT | RoundedViewHelper.TOP_RIGHT;
+    }
 
     roundedViewHelper = new RoundedViewHelper(context, config.getCornerRadius(), corners);
 

--- a/Android/notifications/src/main/java/com/facebook/notifications/internal/view/HeroView.java
+++ b/Android/notifications/src/main/java/com/facebook/notifications/internal/view/HeroView.java
@@ -116,6 +116,12 @@ public class HeroView extends RelativeLayout {
   @Override
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     LayoutParams params = (LayoutParams) assetView.getLayoutParams();
+    // Params can return null if the assetView is not yet attached to the screen.
+    if (params == null) {
+      super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+      return;
+    }
+
     params.height = LayoutParams.WRAP_CONTENT;
 
     super.onMeasure(widthMeasureSpec, heightMeasureSpec);


### PR DESCRIPTION
Looks like we were always trying to get/set the height of the `assetView` in the HeroView, even though we never add it as a subview.
This produced a NullPointerException. Tested with any of the example payloads by removing `hero` portion of the payload.
Also, as a result - we needed to handle the corner radius case in BodyView (which turns out is handled in ActionsView, but not in BodyView).