### PR TITLE
Remove requirement on containing a push campaign identifier in the payload.

### DIFF
--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.google.gms:google-services:1.3.0'
     }
 }

--- a/Android/notifications-example/src/main/assets/example1.json
+++ b/Android/notifications-example/src/main/assets/example1.json
@@ -1,7 +1,4 @@
 {
-  "fb_push_payload" : {
-    "campaign" : "1"
-  },
   "fb_push_card": {
     "version" : "1.0",
     "dismissColor": "#334D5CFF",

--- a/Android/notifications-example/src/main/java/com/facebook/notifications/sample/MainActivity.java
+++ b/Android/notifications-example/src/main/java/com/facebook/notifications/sample/MainActivity.java
@@ -89,8 +89,12 @@ public class MainActivity extends AppCompatActivity {
       JSONObject json = new JSONObject(output.toString());
 
       Bundle bundle = new Bundle();
-      bundle.putString("fb_push_payload", json.getJSONObject("fb_push_payload").toString());
       bundle.putString("fb_push_card", json.getJSONObject("fb_push_card").toString());
+      JSONObject pushPayload = json.optJSONObject("fb_push_payload");
+      if (pushPayload != null) {
+        bundle.putString("fb_push_payload", pushPayload.toString());
+      }
+
 
       output.close();
       inputStream.close();

--- a/iOS/FBNotificationsExample/FBNotificationsExample/Resources/Examples/example1.json
+++ b/iOS/FBNotificationsExample/FBNotificationsExample/Resources/Examples/example1.json
@@ -1,7 +1,4 @@
 {
-  "fb_push_payload" : {
-    "campaign" : "1"
-  },
   "fb_push_card": {
     "version" : "1.0",
     "dismissColor": "#334D5CFF",


### PR DESCRIPTION
If the card is not coming from FB Analytics Backend or if it doesn't contain campaign identifier - we are throwing a null pointer exception.
We actually should be gracefully handling it and not crashing.