### PR TITLE
Add missing documentation for public iOS headers.

### DIFF
--- a/iOS/FBNotifications/FBNotifications/FBNCardViewController.h
+++ b/iOS/FBNotifications/FBNotifications/FBNCardViewController.h
@@ -55,15 +55,46 @@ NS_ASSUME_NONNULL_BEGIN
 */
 @interface FBNCardViewController : UIViewController
 
+/**
+ The delegate of the card view controller.
+ */
 @property (nonatomic, weak) id<FBNCardViewControllerDelegate> delegate;
 
 ///--------------------------------------
 #pragma mark - Unavailable Methods
 ///--------------------------------------
 
+/**
+ Allocates memory and initializes a new instance into it.
+
+ @warning This method is unavaialble. Please use `FBNotificationsManager` to create the view controller.
+ */
 + (instancetype)new NS_UNAVAILABLE;
+
+/**
+ Initializes a new instance.
+
+ @warning This method is unavaialble. Please use `FBNotificationsManager` to create the view controller.
+ */
 - (instancetype)init NS_UNAVAILABLE;
-- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
+
+/**
+ Returns an object initiailized from data in a given unarchiver.
+
+ @param decoder The unarchiver object.
+ 
+ @warning This method is unavaialble. Please use `FBNotificationsManager` to create the view controller.
+ */
+- (nullable instancetype)initWithCoder:(NSCoder *)decoder NS_UNAVAILABLE;
+
+/**
+ Returns a newly initialized view controller with the nib file in the specified bundle.
+
+ @param nibNameOrNil   The name of the nib file to associate with the view controller or `nil`.
+ @param nibBundleOrNil he bundle in which to search for the nib file or `nil`.
+ 
+ @warning This method is unavaialble. Please use `FBNotificationsManager` to create the view controller.
+ */
 - (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 
 @end

--- a/iOS/FBNotifications/FBNotifications/FBNotificationsManager.h
+++ b/iOS/FBNotifications/FBNotifications/FBNotificationsManager.h
@@ -64,7 +64,18 @@ typedef void(^FBNLocalNotificationCreationCompletion)(UILocalNotification *_Null
  */
 + (instancetype)sharedManager;
 
+/**
+ Initializes a new instance.
+
+ @warning This method is unavaialble. Please use `sharedManager`.
+ */
 - (instancetype)init NS_UNAVAILABLE;
+
+/**
+ Allocates memory and initializes a new instance into it.
+
+ @warning This method is unavaialble. Please use `sharedManager`.
+ */
 + (instancetype)new NS_UNAVAILABLE;
 
 ///--------------------------------------


### PR DESCRIPTION
CocoaDocs.org reports that we have 61% documentation coverage, which is not ideal.
Add all the missing documentation, including for unavailable methods.