### PR TITLE
Crash when content is NSNull

### DIFF
--- a/iOS/FBNotifications/FBNotifications/Internal/Models/Components/FBNCardTextContent.m
+++ b/iOS/FBNotifications/FBNotifications/Internal/Models/Components/FBNCardTextContent.m
@@ -62,7 +62,7 @@ FBNCardContentVerticalAlignment FBNCardContentVerticalAlignmentFromString(NSStri
 }
 
 + (nullable instancetype)contentFromDictionary:(nullable NSDictionary<NSString *, id> *)dictionary {
-    if (!dictionary || [dictionary isEqual:[NSNull null]]) {
+    if (!dictionary || dictionary == NSNull.null) {
         return nil;
     }
     return [[self alloc] initFromDictionary:dictionary];

--- a/iOS/FBNotifications/FBNotifications/Internal/Models/Components/FBNCardTextContent.m
+++ b/iOS/FBNotifications/FBNotifications/Internal/Models/Components/FBNCardTextContent.m
@@ -62,7 +62,7 @@ FBNCardContentVerticalAlignment FBNCardContentVerticalAlignmentFromString(NSStri
 }
 
 + (nullable instancetype)contentFromDictionary:(nullable NSDictionary<NSString *, id> *)dictionary {
-    if (!dictionary) {
+    if (!dictionary || [dictionary isEqual:[NSNull null]]) {
         return nil;
     }
     return [[self alloc] initFromDictionary:dictionary];


### PR DESCRIPTION
When sending a test push notification, some of the fields are NSNull instead of nil, causing a crash when trying to access certain content