### PR TITLE
Fix warnings in Xcode 9.

### DIFF
--- a/iOS/FBNotifications/FBNotifications/Internal/Utilities/FBNCardViewUtilities.h
+++ b/iOS/FBNotifications/FBNotifications/Internal/Utilities/FBNCardViewUtilities.h
@@ -54,6 +54,6 @@ extern CGFloat FBNFloatAdjustToScreenScale(CGFloat value, NSRoundingMode roundin
 #pragma mark - Top Most View Controller
 ///--------------------------------------
 
-extern UIViewController *_Nullable FBNApplicationTopMostViewController();
+extern UIViewController *_Nullable FBNApplicationTopMostViewController(void);
 
 NS_ASSUME_NONNULL_END

--- a/iOS/FBNotifications/FBNotifications/Internal/Utilities/FBNCardViewUtilities.m
+++ b/iOS/FBNotifications/FBNotifications/Internal/Utilities/FBNCardViewUtilities.m
@@ -118,7 +118,7 @@ CGFloat FBNFloatAdjustToScreenScale(CGFloat value, NSRoundingMode roundingMode) 
     return value;
 }
 
-UIViewController *_Nullable FBNApplicationTopMostViewController() {
+UIViewController *_Nullable FBNApplicationTopMostViewController(void) {
     UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
     UIViewController *viewController = keyWindow.rootViewController;
     while (viewController.presentedViewController && !viewController.presentedViewController.isBeingDismissed) {


### PR DESCRIPTION
Without this change we get the warning:
`This function declaration is not a prototype`